### PR TITLE
Update to .NET 10, modernize Startup, and refresh deps

### DIFF
--- a/TemperatureHub/AppData/dummy.txt
+++ b/TemperatureHub/AppData/dummy.txt
@@ -1,0 +1,1 @@
+﻿AppData folder

--- a/TemperatureHub/Dockerfile
+++ b/TemperatureHub/Dockerfile
@@ -1,11 +1,10 @@
-#FROM microsoft/dotnet:2.2-aspnetcore-runtime-stretch-slim-arm32v7 AS base
-FROM microsoft/dotnet:2.2-aspnetcore-runtime-stretch-slim AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble-chiseled AS base
 
 WORKDIR /app
 EXPOSE 5000
 
 
-FROM microsoft/dotnet:2.2-sdk AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0-noble AS build
 WORKDIR /src
 COPY ["TemperatureHub.csproj", ""]
 RUN dotnet restore "TemperatureHub.csproj"
@@ -15,16 +14,16 @@ RUN dotnet build "TemperatureHub.csproj" -c Release -o /app
 
 FROM build AS publish
 RUN dotnet publish "TemperatureHub.csproj" -c Release -o /app
+#RUN mkdir -p /app/AppData
 
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app .
-RUN mkdir -p /app/AppData
 VOLUME /app/AppData
-ENV ClientId ClientId
-ENV ClientSecret ClientSecret
-ENV Username Username
-ENV Password Password
+ENV ClientId=ClientId
+ENV ClientSecret=ClientSecret
+ENV Username=Username
+ENV Password=Password
 ENTRYPOINT ["dotnet", "TemperatureHub.dll"]
 
 #docker run -d -v C:\DockerVolume\SensorData:/app/AppData -p 5000:5000 ImageId

--- a/TemperatureHub/Startup.cs
+++ b/TemperatureHub/Startup.cs
@@ -18,6 +18,7 @@ using TemperatureHub.Repository;
 using System.Threading;
 using System.Net.Mail;
 using System.Net;
+using Microsoft.Extensions.Hosting;
 
 namespace TemperatureHub
 {
@@ -30,7 +31,7 @@ namespace TemperatureHub
 
         private static Timer timer;
 
-        public Startup(IHostingEnvironment env)
+        public Startup(IWebHostEnvironment env)
         {
             var builder = new ConfigurationBuilder()
                     .SetBasePath(env.ContentRootPath)
@@ -62,7 +63,7 @@ namespace TemperatureHub
                  .AllowCredentials());
             });
 
-            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
+            services.AddMvc();
  
             var appSettingsSection = Configuration.GetSection("AppSettings");
             services.Configure<AppSettings>(appSettingsSection);
@@ -75,7 +76,7 @@ namespace TemperatureHub
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             if (env.IsDevelopment())
             {
@@ -110,9 +111,10 @@ namespace TemperatureHub
 
 
             app.UseCors("CorsPolicy"); //Only 4 test. 
-            app.UseMvc();
+            app.UseRouting();
+            app.UseEndpoints(endpoints => endpoints.MapControllers());
 
-            var lifeTime = app.ApplicationServices.GetService<IApplicationLifetime>();
+            var lifeTime = app.ApplicationServices.GetService<Microsoft.Extensions.Hosting.IHostApplicationLifetime>();
             lifeTime.ApplicationStopping.Register(() =>
             {
                 SQLiteFileRepository.CleanUp();

--- a/TemperatureHub/TemperatureHub.csproj
+++ b/TemperatureHub/TemperatureHub.csproj
@@ -1,19 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
-    <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
+    <TargetFramework>net10.0</TargetFramework>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <LangVersion>latest</LangVersion>
     <UserSecretsId>a7024c13-d169-4f8f-a58b-24b73b7c3453</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
-	<PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.2.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.0.2105168" />
-    <PackageReference Include="sqlite-net-pcl" Version="1.5.231" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="sqlite-net-pcl" Version="1.9.172" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="AppData\dummy.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Upgrade Dockerfile and project to .NET 10.0, replacing deprecated .NET Core 2.2 images and settings.
- Refactor Startup.cs to use IWebHostEnvironment, endpoint routing, and updated application lifetime handling.
- Remove obsolete ASP.NET Core 2.2 package references; add Newtonsoft.Json and update sqlite-net-pcl to 1.9.172.
- Add AppData/dummy.txt to output for data volume support.